### PR TITLE
errores de manejo de la ventana de historial corregidos

### DIFF
--- a/HistoryScreen.tsx
+++ b/HistoryScreen.tsx
@@ -25,7 +25,7 @@ export default function HistoryScreen({ route, navigation }) {
     return (
         <SafeAreaView style={styles.container}>
             <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
-                <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+                <TouchableOpacity onPress={() => route.params?.onClose ? route.params.onClose() : navigation.goBack()} style={styles.backBtn}>
                     <Text style={styles.backBtnText}>Volver</Text>
                 </TouchableOpacity>
                 <Text style={[styles.title, { flex: 1 }]}>Historial de Transacciones</Text>

--- a/MainApp.tsx
+++ b/MainApp.tsx
@@ -224,30 +224,52 @@ export default function MainApp() {
         <Stack.Navigator
           id={undefined}
           initialRouteName="Home"
-          screenOptions={({ route, navigation }) => ({
-            headerShown: false,
-            cardStyleInterpolator: (props) => {
-              const { current, layouts, next, inverted, closing, index } = props;
-              // Si estamos yendo a Home desde Goals, animar desde la izquierda
-              if (route.name === 'Home' && navigation.getState().routes[navigation.getState().index - 1]?.name === 'Goals') {
-                return {
-                  cardStyle: {
-                    transform: [
-                      {
-                        translateX: current.progress.interpolate({
-                          inputRange: [0, 1],
-                          outputRange: [-layouts.screen.width, 0],
-                        }),
-                      },
-                    ],
-                  },
-                };
-              }
-              // Por defecto, animación horizontal iOS
-              return CardStyleInterpolators.forHorizontalIOS(props);
-            },
-            gestureEnabled: true,
-          })}
+          screenOptions={({ route, navigation }) => {
+            let gestureEnabled = true;
+            if (route.name === 'Home' || route.name === 'Goals') {
+              gestureEnabled = false;
+            }
+            return {
+              headerShown: false,
+              gestureEnabled,
+              cardStyleInterpolator: (props) => {
+                const { current, layouts } = props;
+                const prevRoute = navigation.getState().routes[navigation.getState().index - 1]?.name;
+                // Si estamos yendo a Home desde TransactionHistory, animar desde la izquierda
+                if (route.name === 'Home' && prevRoute === 'TransactionHistory') {
+                  return {
+                    cardStyle: {
+                      transform: [
+                        {
+                          translateX: current.progress.interpolate({
+                            inputRange: [0, 1],
+                            outputRange: [-layouts.screen.width, 0],
+                          }),
+                        },
+                      ],
+                    },
+                  };
+                }
+                // Si estamos yendo a Home desde Goals, animar desde la izquierda
+                if (route.name === 'Home' && prevRoute === 'Goals') {
+                  return {
+                    cardStyle: {
+                      transform: [
+                        {
+                          translateX: current.progress.interpolate({
+                            inputRange: [0, 1],
+                            outputRange: [-layouts.screen.width, 0],
+                          }),
+                        },
+                      ],
+                    },
+                  };
+                }
+                // Por defecto, animación horizontal iOS
+                return CardStyleInterpolators.forHorizontalIOS(props);
+              },
+            };
+          }}
         >
           <Stack.Screen name="Home">
             {props => (
@@ -273,7 +295,10 @@ export default function MainApp() {
                 {...props}
                 transactions={transactions}
                 onClose={() => {
-                  resetNavigationState('Home'); // Restablecer estado para Home
+                  // Restaurar menús y estado según la pantalla previa
+                  const navState = props.navigation.getState?.();
+                  const prevRoute = navState?.routes[navState.index - 1]?.name;
+                  resetNavigationState(prevRoute || 'Home');
                   props.navigation.goBack();
                 }}
                 onEdit={handleEditTransaction}

--- a/MenuVisibilityContext.tsx
+++ b/MenuVisibilityContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useState, useContext } from 'react';
+
+interface MenuVisibilityContextType {
+  menusVisible: boolean;
+  setMenusVisible: (visible: boolean) => void;
+}
+
+const MenuVisibilityContext = createContext<MenuVisibilityContextType | undefined>(undefined);
+
+export const MenuVisibilityProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [menusVisible, setMenusVisible] = useState(true);
+  return (
+    <MenuVisibilityContext.Provider value={{ menusVisible, setMenusVisible }}>
+      {children}
+    </MenuVisibilityContext.Provider>
+  );
+};
+
+export const useMenuVisibility = () => {
+  const context = useContext(MenuVisibilityContext);
+  if (!context) {
+    throw new Error('useMenuVisibility must be used within a MenuVisibilityProvider');
+  }
+  return context;
+};

--- a/components/TransactionHistoryScreen.tsx
+++ b/components/TransactionHistoryScreen.tsx
@@ -34,12 +34,11 @@ export default function TransactionHistoryScreen({ transactions, onClose, onEdit
   // Listener para el hardware back button o gesture de volver atrás
   useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      // Llamar a onClose cuando se use el gesto de volver atrás
-      onClose();
+      // Solo restaurar el estado global, no llamar a onClose ni goBack
+      // Se espera que MainApp maneje el resetNavigationState en onStateChange
     });
-
     return unsubscribe;
-  }, [navigation, onClose]);
+  }, [navigation]);
 
   // Abrir modal de edición localmente
   const handleEdit = (idx: number, data: any) => {


### PR DESCRIPTION
Error de despliegue entre las pantallas de historial, home page y metas. Navegar entre dichas ventanas generaba errores de pila y crasheaba la app.